### PR TITLE
Add char mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Width Test (&#x5E45;&#x30C6;&#x30B9;&#x30C8; is its Japanese name) is a special-
 
 * CIDs 3 through 6 are full-, half-, third-, and quarter-width glyphs that are made up of black boxes that correspond to the denominator portion of their corresponding fractions, and the use of the 'fwid', 'hwid', 'twid', or 'qwid' GSUB features will substitute zero (U+0030) with the appropriate glyph.
 
+* In addition, one (U+0031) through four (U+0034) are mapped to CIDs 3 through 6 for the ease of creating reference test. The fullwidth form of zero (U+FF10) is also mapped to CID 3.
+
 The image below shows the glyphs for CIDs 2 through 6 with registration marks:
 
 ![alt text](https://raw.githubusercontent.com/adobe-fonts/width-test/master/resources/width-test.jpg "img-View")

--- a/UniWidthTest-UTF32-H
+++ b/UniWidthTest-UTF32-H
@@ -64,9 +64,14 @@ end def
   <00000000> <0010FFFF>
 endcodespacerange
 
-2 begincidchar
+7 begincidchar
 <00000020> 1
 <00000030> 2
+<00000031> 3
+<00000032> 4
+<00000033> 5
+<00000034> 6
+<0000FF10> 3
 endcidchar
 
 endcmap


### PR DESCRIPTION
This commit adds 5 mappings to the test font:
1. U+0031 ~ U+0034 are mapped to CIDs 3 ~ 6 so that reference tests could be created via using those characters in reference documents.
2. U+FF10 is mapped to CID 3 in addition so that it can also be used to test fullwidth text transform (CSS text-transform: full-width).

The font file is not updated here because I failed to generate an identical file before I touched anything, so I assumed my AFDKO is somehow different from what you were using. Thus, I'm afraid to include the updated font file in the commit. Also I suppose you may want to bump the version number if this pull request is accepted.
